### PR TITLE
reload foreman-proxy service when cert changes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -130,7 +130,7 @@ class foreman_proxy_content (
   class { '::certs::foreman_proxy':
     hostname => $foreman_proxy_fqdn,
     require  => Package['foreman-proxy'],
-    before   => Service['foreman-proxy'],
+    notify   => Service['foreman-proxy'],
   } ~>
   class { '::certs::katello':
     deployment_url => $foreman_proxy_content::rhsm_url,

--- a/manifests/reverse_proxy.pp
+++ b/manifests/reverse_proxy.pp
@@ -26,12 +26,15 @@ class foreman_proxy_content::reverse_proxy (
     ssl_verify_client => 'optional',
     ssl_verify_depth  => 10,
     request_headers   => ['set X_RHSM_SSL_CLIENT_CERT "%{SSL_CLIENT_CERT}s"'],
-    proxy_pass        => [{
-      'path'         => $path,
-      'url'          => $url,
-      'reverse_urls' => [$path, $url]
-    }],
-    error_documents   => [{
+    proxy_pass        => [
+      {
+        'path'         => $path,
+        'url'          => $url,
+        'reverse_urls' => [$path, $url]
+      }
+    ],
+    error_documents   => [
+      {
         'error_code' => '503',
         'document'   => '\'{"displayMessage": "Internal error, contact administrator", "errors": ["Internal error, contact administrator"], "status": "500" }\''
       },


### PR DESCRIPTION
This commit reload foreman-proxy service when the cert changes. This has
previously been done in puppet-certs. To reduce dependencies of
puppet-certs, moving it here.