### PR TITLE
fixes #19269 - allow browsing /pub over https

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -201,7 +201,7 @@ class foreman_proxy_content (
     }
 
     pulp::apache::fragment{'gpg_key_proxy':
-      ssl_content => template('foreman_proxy_content/_pulp_gpg_proxy.erb'),
+      ssl_content => template('foreman_proxy_content/_pulp_gpg_proxy.erb', 'foreman_proxy_content/httpd_pub.erb'),
     }
   }
 


### PR DESCRIPTION
Currently the pub template is only in HTTP vhost, but /pub should be available over https too which is in the pulp vhost.

