### PR TITLE
Explicitly set ssl_certs_dir to an empty string

### DIFF
--- a/manifests/reverse_proxy.pp
+++ b/manifests/reverse_proxy.pp
@@ -18,6 +18,7 @@ class foreman_proxy_content::reverse_proxy (
     ssl_cert          => $certs::apache::apache_cert,
     ssl_key           => $certs::apache::apache_key,
     ssl_ca            => $certs::ca_cert,
+    ssl_certs_dir     => '',
     ssl_verify_client => 'optional',
     ssl_verify_depth  => 10,
     request_headers   => ['set X_RHSM_SSL_CLIENT_CERT "%{SSL_CLIENT_CERT}s"'],


### PR DESCRIPTION
Previously the SSLCACertificatePath would be set to the system certificate store thus accepting any certificate signed by a CA as valid client certificate.

puppetlabs-apache 1.11.1/2.1.0 will change this and assigned CVE-2017-2299 to it but this means we don't have to wait for that release and require the latest version.

This is similar to https://github.com/Katello/puppet-pulp/pull/275