### PR TITLE
use foreman_url for reverse proxy upstream

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -88,7 +88,7 @@ class foreman_proxy_content (
   }
 
   $foreman_proxy_fqdn = $::fqdn
-  $foreman_url = "https://${parent_fqdn}"
+  $foreman_url = $::foreman_proxy::foreman_base_url
   $reverse_proxy_real = $pulp or $reverse_proxy
 
   $rhsm_port = $reverse_proxy_real ? {

--- a/manifests/reverse_proxy.pp
+++ b/manifests/reverse_proxy.pp
@@ -1,7 +1,7 @@
 # Adds http reverse-proxy to parent conf
 class foreman_proxy_content::reverse_proxy (
   $path = '/',
-  $url  = "https://${::foreman_proxy_content::parent_fqdn}/",
+  $url  = "${foreman_proxy_content::foreman_url}/",
   $port = $::foreman_proxy_content::reverse_proxy_port,
 ) {
   include ::apache

--- a/spec/classes/foreman_proxy_content_spec.rb
+++ b/spec/classes/foreman_proxy_content_spec.rb
@@ -30,7 +30,7 @@ describe 'foreman_proxy_content' do
         it { should_not contain_class('foreman_proxy_content::dispatch_router') }
 
         it { should contain_pulp__apache__fragment('gpg_key_proxy').with({
-          :ssl_content => %r{ProxyPass /katello/api/repositories/}} ) }
+          :ssl_content => %r{ProxyPass /katello/api/repositories/ https://foo\.example\.com/katello/api/repositories/}} ) }
       end
     end
   end

--- a/templates/_pulp_gpg_proxy.erb
+++ b/templates/_pulp_gpg_proxy.erb
@@ -1,5 +1,5 @@
-  ProxyPass /katello/api/repositories/ https://<%= @parent_fqdn %>/katello/api/repositories/
+  ProxyPass /katello/api/repositories/ <%= @foreman_url %>/katello/api/repositories/
   <Location /katello/api/repositories/>
-    ProxyPassReverse https://<%= @parent_fqdn %>/
+    ProxyPassReverse <%= @foreman_url %>/
   </Location>
   SSLProxyEngine On


### PR DESCRIPTION
This is step one of dropping `parent_fqdn` parameter. This takes the upstream URL for the reverse proxy from `foreman_proxy` module.
Step two will be to rename `parent_fqdn` (after this change: only the upsteam of the qpid router hub) to something like `qpid_broker_fqdn`.